### PR TITLE
Modified the readthedocs YAML file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,4 @@ formats: all
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-    - requirements: requirements.txt
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
The install requirements were in the wrong location, so the API docs couldn't be automatically generated