### PR TITLE
Config file SPI names to match new naming scheme

### DIFF
--- a/pyspi/config.yaml
+++ b/pyspi/config.yaml
@@ -367,7 +367,7 @@
       k_history: 10
       l_history: 1
 
-  IntegratedInfo:
+  IntegratedInformation:
     - phitype: "star"
 
     - phitype: "star"


### PR DESCRIPTION
Fixed integrated info name to be "IntegratedInformation" rather than "IntegratedInfo" in the "config.yaml" file to match the new SPI naming style convention.