### PR TITLE
Incorporate option for reduced set of SPIs

### DIFF
--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -32,12 +32,14 @@ class Calculator:
             Any set of strings by which you want to label the calculator. This can be useful later for classification purposes, defaults to None.
         fast (bool, optional):
             If True, use a hand-picked set of ~210 SPIs that compute quickly but are still relatively comprehensive, defaults to False.
+        sonnet (bool, optional):
+            If True, use a hand-picked set of 14 SPIs that represent the set of 14 hierarchical clusters of SPIs detailed in the preprint, defaults to False.
         configfile (str, optional):
             The location of the YAML configuration file. See :ref:`Using a reduced SPI set`, defaults to :code:`'</path/to/pyspi>/pyspi/config.yaml'`
     """
 
     def __init__(
-        self, dataset=None, name=None, labels=None, fast=False, configfile=None
+        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, configfile=None
     ):
         self._spis = {}
 
@@ -45,6 +47,10 @@ class Calculator:
             if fast is True:
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fast_config.yaml"
+                )
+            elif sonnet is True:
+                configfile = (
+                    os.path.dirname(os.path.abspath(__file__)) + "/sonnet_config.yaml"
                 )
             else:
                 configfile = os.path.dirname(os.path.abspath(__file__)) + "/config.yaml"

--- a/pyspi/sonnet_config.yaml
+++ b/pyspi/sonnet_config.yaml
@@ -1,0 +1,79 @@
+# Basic statistics
+.statistics.basic:
+  # Covariance
+  Covariance:
+    - estimator: EmpiricalCovariance
+
+.statistics.distance:
+  DynamicTimeWarping:
+    - global_constraint: itakura
+
+  Barycenter:
+  - mode: dtw
+    statistic: mean
+
+.statistics.causal:
+
+  # Additive noise model
+  AdditiveNoiseModel:
+
+
+# Information-theoretic statistics
+.statistics.infotheory:
+  DirectedInfo: # No theiler window yet
+    - estimator: gaussian
+
+  # Transfer entropy
+  TransferEntropy:
+    - estimator: kraskov
+      prop_k: 4
+      auto_embed_method: MAX_CORR_AIS
+      k_search_max: 10
+      tau_search_max: 4
+      dyn_corr_excl: AUTO
+  
+  # Integrated information
+  IntegratedInformation:
+    - phitype: 'star'
+
+# statistics that analyse in the frequency-domain (see Schoegl and Supp, 2006)
+.statistics.spectral:
+
+  CoherenceMagnitude:
+    - fs: 1
+
+  PhaseSlopeIndex:
+    - fmin: 0
+      fmax: 0.5
+
+  PhaseLagIndex:
+
+    - fs: 1
+      statistic: max
+
+  SpectralGrangerCausality:
+      # Non-parametric Granger causality (no VAR model)
+    - method: nonparametric
+      fmin: 0
+      fmax: 0.5
+      statistic: mean
+
+# statistics that analyse in the wavlet-domain (only Mortlet wavelet's at the moment)
+.statistics.wavelet:
+  PhaseSlopeIndex:
+    - fs: 1
+
+.statistics.misc:
+  # Cointegration
+  Cointegration:
+    - method: aeg
+      statistic: tstat
+      autolag: aic
+      maxlag: 10
+      trend: ct
+
+  # Power envelope correlation
+  PowerEnvelopeCorrelation:
+    - orth: False
+      log: False
+      absolute: False


### PR DESCRIPTION
This PR would introduce a flag option for a user to use a set of 14 manually curated SPIs that represent the 14 SPI modules identified via hierarchical clustering in the pyspi preprint. The feature set name is provisionally "sonnet" (naming creds to @benfulcher) reflecting the 14 lines in a traditional Shakespearean sonnet, and can be invoked just like the set of fast SPIs with a --sonnet flag.