### PR TITLE
Create "fabfour" minimal SPI subset for examples/tutorials

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -28,7 +28,21 @@ If you want more control over how the MTS are treated upon input, you can direct
 Using a reduced SPI set
 -----------------------
 
-You can easily use a subset of the SPIs by copying a version of the :code:`config.yaml` file to a local directory and removing those you don't want the calculator to compute.
+The :class:`~pyspi.calculator.Calculator` object computes 283 SPIs by default, but you may only be interested in a subset of these.
+We provide three pre-configured reduced SPI subsets that you may wish to try:
+
+* :code:`fast`: Most SPIs (excluding those that are computationally expensive)
+* :code:`sonnet` - 14 SPIs, one from each of the data-driven clusters as described in `Cliff et al. (2023) <https://arxiv.org/abs/2201.11941>`_
+* :code:`fabfour` - 4 SPIs that are simple and computationally efficient: Pearson correlation, Spearman correlation, directed information with a Gaussian density estimator, and the power envelope correlation.
+
+You may specify any one of these subsets when you instantiate the :code:`Calculator` object:
+
+.. code-block::
+
+    from pyspi.calculator import Calculator
+    calc = Calculator(dataset=dataset, subset='sonnet')
+
+Alternatively, if you would like to use your own bespoke set of SPIs, you can copy a version of the :code:`config.yaml` file to your workspace and edit it to remove any SPIs that you would not like the :code:`Calculator` to compute.
 First, copy the :code:`config.yaml` file to your workspace:
 
 .. code-block:: console

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -36,8 +36,8 @@ And, using only the :meth:`~pyspi.calculator.Calculator.compute` method, we can 
 
 .. note::
    While we tried to make the calculator as efficient as possible, computing all statistics can take a while (depending on the size of your dataset).
-   You can use a faster set of statistics by instantiating the calculator with :code:`fast=True`, see :class:`~pyspi.calculator.Calculator`.
-   Alternatively, design your own subset of the statistics by following the instructions in :ref:`Using a reduced SPI set`.
+   You can use a faster set of statistics by instantiating the calculator with :code:`subset=fast`, see :class:`~pyspi.calculator.Calculator`.
+   We also provide a reduced set of statistics that are useful for many applications, with the option for users to design their own subset of statistics; see :ref:`Using a reduced SPI set`.
 
 Once the calculator has computed each of the statistics, you can access all values using the :attr:`~pyspi.calculator.Calculator.table` property:
 

--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -39,7 +39,7 @@ class Calculator:
     """
 
     def __init__(
-        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, configfile=None
+        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, fabfour=False, configfile=None
     ):
         self._spis = {}
 
@@ -51,6 +51,10 @@ class Calculator:
             elif sonnet is True:
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/sonnet_config.yaml"
+                )
+            elif fabfour is True:
+                configfile = (
+                    os.path.dirname(os.path.abspath(__file__)) + "/fabfour_config.yaml"
                 )
             else:
                 configfile = os.path.dirname(os.path.abspath(__file__)) + "/config.yaml"

--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -30,29 +30,27 @@ class Calculator:
             The name of the calculator. Mainly used for printing the results but can be useful if you have multiple instances, defaults to None.
         labels (array_like, optional):
             Any set of strings by which you want to label the calculator. This can be useful later for classification purposes, defaults to None.
-        fast (bool, optional):
-            If True, use a hand-picked set of ~210 SPIs that compute quickly but are still relatively comprehensive, defaults to False.
-        sonnet (bool, optional):
-            If True, use a hand-picked set of 14 SPIs that represent the set of 14 hierarchical clusters of SPIs detailed in the preprint, defaults to False.
+        subset (str, optional):
+            A pre-configured subset of SPIs to use. Options are "all", "fast", "sonnet", or "fabfour", defaults to "all".
         configfile (str, optional):
-            The location of the YAML configuration file. See :ref:`Using a reduced SPI set`, defaults to :code:`'</path/to/pyspi>/pyspi/config.yaml'`
+            The location of the YAML configuration file for a user-defined subset. See :ref:`Using a reduced SPI set`, defaults to :code:`'</path/to/pyspi>/pyspi/config.yaml'`
     """
 
     def __init__(
-        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, fabfour=False, configfile=None
+        self, dataset=None, name=None, labels=None, subset="all", configfile=None
     ):
         self._spis = {}
 
         if configfile is None:
-            if fast is True:
+            if subset == "fast":
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fast_config.yaml"
                 )
-            elif sonnet is True:
+            elif subset == "sonnet":
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/sonnet_config.yaml"
                 )
-            elif fabfour is True:
+            elif subset == "fabfour":
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fabfour_config.yaml"
                 )

--- a/pyspi/fabfour_config.yaml
+++ b/pyspi/fabfour_config.yaml
@@ -1,0 +1,21 @@
+# Pearson and Spearman correlation statistics
+.statistics.basic:
+  # Covariance
+  Covariance:
+    - estimator: EmpiricalCovariance
+
+  # Spearman's correlation coefficient
+  SpearmanR:
+    - squared: True
+
+# Directed information with a Gaussian density estimator
+.statistics.infotheory:
+  DirectedInfo:
+    - estimator: gaussian
+
+# Power envelope correlation
+.statistics.misc:
+  PowerEnvelopeCorrelation:
+    - orth: False
+      log: False
+      absolute: False

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     package_data={'': ['config.yaml',
                        'sonnet_config.yaml',
                         'fast_config.yaml',
+                        'fabfour_config.yaml',
                         'lib/jidt/infodynamics.jar',
                         'lib/PhiToolbox/Phi/phi_comp.m',
                         'lib/PhiToolbox/Phi/phi_star_Gauss.m',


### PR DESCRIPTION
This PR creates a minimal subset of four SPIs for simple examples/tutorials that includes the following four SPIs:

- Pearson correlation (`cov_EmpiricalCovariance`)
- Spearman correlation (`spearman`)
- Directed information with a Gaussian density estimator (`di_gaussian`)
- Power envelope correlation (`pec`)

The proposed SPI subset name is "fabfour" :)