### PR TITLE
Update setup.py to include new octaveless subset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
                        'sonnet_config.yaml',
                         'fast_config.yaml',
                         'fabfour_config.yaml',
+                        'octaveless_config.yaml',
                         'lib/jidt/infodynamics.jar',
                         'lib/PhiToolbox/Phi/phi_comp.m',
                         'lib/PhiToolbox/Phi/phi_star_Gauss.m',


### PR DESCRIPTION
Update the setup.py file to include the .yaml file corresponding to the octaveless SPI subset.