### PR TITLE
Bump torch from 1.10.0 to 1.13.1

### DIFF
--- a/.github/workflows/run_unit_tests.yaml
+++ b/.github/workflows/run_unit_tests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ jpype1==1.2.0
 sktime==0.8.0
 dill==0.3.2
 spectral-connectivity==0.2.4.dev0
-torch==1.10.0
+torch==1.13.1
 cdt==0.5.23
 oct2py==5.2.0
 tslearn==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
         'sktime==0.8.0',
         'dill==0.3.2',
         'spectral-connectivity==0.2.4.dev0',
-        'torch==1.10.0',
+        'torch==1.13.1',
         'cdt==0.5.23',
         'oct2py==5.2.0',
         'tslearn==0.5.2',
@@ -59,8 +59,7 @@ setup(
                         'lib/PhiToolbox/utility/Gauss/logdet.m',
                         'data/cml.npy',
                         'data/forex.npy',
-                        'data/standard_normal.npy'
-                        '']},
+                        'data/standard_normal.npy']},
     include_package_data=True,
     version='0.4.0',
     description='Library for pairwise analysis of time series data.',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ setup(
                         'lib/PhiToolbox/utility/Gauss/H_gauss.m',
                         'lib/PhiToolbox/utility/Gauss/logdet.m',
                         'data/cml.npy',
-                        'data/forex.npy']},
+                        'data/forex.npy',
+                        'data/standard_normal.npy'
+                        '']},
     include_package_data=True,
     version='0.4.0',
     description='Library for pairwise analysis of time series data.',

--- a/setup.py
+++ b/setup.py
@@ -34,15 +34,6 @@ testing_extras = [
     'pytest==5.4.2',  # unittest.TestCase funkyness, see commit 77c1505ab
 ]
 
-docs_extras = [
-    'Sphinx >= 3.0.0',  # Force RTD to use >= 3.0.0
-    'docutils',
-    'pylons-sphinx-themes >= 1.0.8',  # Ethical Ads
-    'pylons_sphinx_latesturl',
-    'repoze.sphinx.autointerface',
-    'sphinx-copybutton',
-    'sphinxcontrib-autoprogram',
-]
 
 setup(
     name='pyspi',
@@ -89,5 +80,5 @@ setup(
         "Topic :: Scientific/Engineering :: Medical Science Apps.",
     ],
     install_requires=install_requires,
-    extras_require={'testing': testing_extras, 'docs': docs_extras}
+    extras_require={'testing': testing_extras}
 )


### PR DESCRIPTION
The following changes were made:

1. Bumped torch 1.10.0 to 1.13.1 as per dependabot recommendation. Unit tested on the dev branch and verified to pass all tests with torch 1.13.1. 
2. Removed references/dependencies for old docs in setup.py file 
3. Added references to setup.py file for new standard_normal.npy file.
4. Added an additional python version (3.9) to the git actions workflow. The motivation behind using both python 3.8 and python 3.9 was that Windows users experiencing compatibility issues when installing pyspi were recommended to downgrade to python 3.8 (as per pyspi docs). Thus, it would make sense to also unit test in this environment for our Windows users on python 3.8. Both python 3.9 and 3.8 pass unit tests as of this merge. 