### PR TITLE
Add pyproject.toml and change package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires      = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pySPI"
+name = "pyspi-lib"
 version = "0.4.2"
 authors = [
     { name ="Oliver M. Cliff", email="oliver.m.cliff@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
+dynamic = ["dependencies", "optional-dependencies"]
 
 [project.urls]
 Homepage = "https://github.com/DynamicsAndNeuralSystems/pyspi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires      = ["setuptools>=61.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyspi"
+version = "0.4.2"
+authors = [
+    { name ="Oliver M. Cliff", email="oliver.m.cliff@gmail.com"},
+]
+maintainers = [
+    {name = "Joshua B. Moore"},
+    {email = "joshua.moore@sydney.edu.au"},
+]
+description = "Library for pairwise analysis of time series data."
+readme = "README.md"
+license = {text = "GNU General Public License v3 (GPLv3)"}
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Development Status :: 1 - Planning",
+    "Operating System :: POSIX :: Linux",
+    "Intended Audience :: Science/Research",
+    "Environment :: Console",
+    "Environment :: Other Environment",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+]
+
+[project.urls]
+Homepage = "https://github.com/DynamicsAndNeuralSystems/pyspi"
+Documentation = "https://time-series-features.gitbook.io/pyspi/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires      = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pyspi"
+name = "pySPI"
 version = "0.4.2"
 authors = [
     { name ="Oliver M. Cliff", email="oliver.m.cliff@gmail.com"},

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ testing_extras = [
 
 
 setup(
-    name='pyspi',
+    name='pySPI',
     packages=find_packages(),
     package_data={'': ['config.yaml',
                        'sonnet_config.yaml',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ testing_extras = [
 
 
 setup(
-    name='pySPI',
+    name='pyspi-lib',
     packages=find_packages(),
     package_data={'': ['config.yaml',
                        'sonnet_config.yaml',


### PR DESCRIPTION
In this PR, I've created a .toml file for configuring the pyspi package for publishing to PyPI. As the package name "pyspi" was taken, I modified the package name in the .toml and `setup.py` file to be `pyspi-lib`. The package has since been built and published to PyPI under the name `pyspi-lib` and is accessible [here](https://pypi.org/project/pyspi-lib/). 