### PR TITLE
Updated project name and requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires      = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pyspi-lib"
+name = "pyspi"
 version = "0.4.2"
 authors = [
     { name ="Oliver M. Cliff", email="oliver.m.cliff@gmail.com"},
@@ -15,7 +15,7 @@ maintainers = [
 description = "Library for pairwise analysis of time series data."
 readme = "README.md"
 license = {text = "GNU General Public License v3 (GPLv3)"}
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.10"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ testing_extras = [
 
 
 setup(
-    name='pyspi-lib',
+    name='pyspi',
     packages=find_packages(),
     package_data={'': ['config.yaml',
                        'sonnet_config.yaml',


### PR DESCRIPTION
In this PR, I have updated the project name from 'pyspi-lib' to 'pyspi' as well as set the python versions to those for which pyspi has been tested and supports. In making these changes, pyspi 0.4.2 is now available on PyPI and is pip installable as 'pyspi', thus replacing 'pyspi-lib'. 