### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
  	<a href="https://zenodo.org/badge/latestdoi/601919618"><img src="https://zenodo.org/badge/601919618.svg" height="20"/></a>
     <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPLv3-blue.svg" height="20"/></a>
     <a href="https://github.com/DynamicsAndNeuralSystems/pyspi/actions/workflows/run_unit_tests.yaml"><img src="https://github.com/DynamicsAndNeuralSystems/pyspi/actions/workflows/run_unit_tests.yaml/badge.svg" height="20"/></a>
-    <a href="https://twitter.com/compTimeSeries"><img src="https://img.shields.io/twitter/url/https/twitter.com/compTimeSeries.svg?style=social&label=Follow%20%40compTimeSeries" height="20"/></a>
- 
+    <a href="https://twitter.com/compTimeSeries"><img src="https://img.shields.io/twitter/url/https/twitter.com/compTimeSeries.svg?style=social&label=Follow%20%40compTimeSeries" height="20"/></a><br>
+    <a href="https://www.python.org"><img src="https://img.shields.io/badge/Python-3.8%20|%203.9-3776AB.svg?style=flat&logo=python&logoColor=white" alt="Python 3.8 | 3.9"></a>
 </p>
 
 _pyspi_ is a comprehensive python library for computing statistics of pairwise interactions (SPIs) from multivariate time-series (MTS) data.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feedback is much appreciated through [issues](https://github.com/DynamicsAndNeur
 <hr style="border-top: 3px solid #bbb;">
 
 ## Installation 📥
-The simplest way to get the _pyspi_ package up and running is to install the package locally using `pip`. 
+The simplest way to get the _pyspi_ package up and running is to install the package using `pip install`. 
 For access to the full library of SPIs, the code requires GNU's [Octave](https://octave.org/download) to be installed on your system.
 
 #### 1. Pre-Install Octave (Optional)
@@ -51,16 +51,10 @@ conda create -n pyspi python=3.9.0
 Once you have created the environment, activate it using `conda activate pyspi`.
 
 #### 3. Install with _pip_
-To install _pyspi_ using a local pip install, download or clone the latest version from the repository:
+Using `pip` for [`pyspi`](https://pypi.org/project/pyspi/):
 ```
-git clone https://github.com/DynamicsAndNeuralSystems/pyspi
+pip install pyspi
 ```
-
-Once you have navigated to the main folder (`pyspi`), you can install using:
-```
-pip install .
-```
-
 
 For a more detailed guide on how to install _pyspi_, as well as how you can use _pyspi_ without first installing Octave, 
 please see the [full documentation](https://time-series-features.gitbook.io/pyspi/installation/installing-pyspi).


### PR DESCRIPTION
Modified the README (and Gitbook) to show the new `pip install pyspi` option as the primary method of installation. 
Also added a badge for python versions currently tested/supported by `pyspi` in the README. 