### PR TITLE
Update TLMI to reflect its directed nature

### DIFF
--- a/pyspi/config.yaml
+++ b/pyspi/config.yaml
@@ -517,7 +517,7 @@
   # Mutual information
   TimeLaggedMutualInfo:
     labels:
-      - undirected
+      - directed
       - nonlinear
       - unsigned
       - bivariate

--- a/pyspi/fast_config.yaml
+++ b/pyspi/fast_config.yaml
@@ -322,7 +322,7 @@
   # Mutual information
   TimeLaggedMutualInfo:
     labels:
-      - undirected
+      - directed
       - nonlinear
       - unsigned
       - bivariate

--- a/pyspi/statistics/infotheory.py
+++ b/pyspi/statistics/infotheory.py
@@ -300,10 +300,10 @@ class MutualInfo(JIDTBase, Undirected):
             return np.NaN
 
 
-class TimeLaggedMutualInfo(MutualInfo):
+class TimeLaggedMutualInfo(JIDTBase, Directed):
     name = "Time-lagged mutual information"
     identifier = "tlmi"
-    labels = ["unsigned", "infotheory", "temporal", "undirected"]
+    labels = ["unsigned", "infotheory", "temporal", "directed"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Time-lagged mutual information is an intrinsically directed (asymmetric) measure, cf. [Schreiber 2000](https://doi.org/10.1103/PhysRevLett.85.461). This PR corrects the corresponding SPI (prefix `tlmi_`) to calculate metrics in a directed manner by updating the inherited class attributes for the `TimeLaggedMutualInfo` object in `infotheory.py`. It also updates the label approrpriately in the `config.yaml` file.