### PR TITLE
update infinity notation for infotheory

### DIFF
--- a/pyspi/statistics/distance.py
+++ b/pyspi/statistics/distance.py
@@ -237,6 +237,8 @@ class Barycenter(Directed, Signed):
             self._statfn = lambda x: np.nanmean(self._preproc(x))
         elif statistic == "max":
             self._statfn = lambda x: np.nanmax(self._preproc(x))
+        elif statistic == "max_time":
+            self._statfn = lambda x: np.argmax(self._preproc(x))
         else:
             raise NameError(f"Unknown statistic: {statistic}")
 

--- a/pyspi/statistics/infotheory.py
+++ b/pyspi/statistics/infotheory.py
@@ -180,7 +180,7 @@ class JIDTBase(Unsigned):
 
         key = self._getkey()
         if key not in data.joint_entropy:
-            data.joint_entropy[key] = np.full((data.n_processes, data.n_processes), -np.infty)
+            data.joint_entropy[key] = np.full((data.n_processes, data.n_processes), -np.inf)
 
         if data.joint_entropy[key][i, j] == -np.inf:
             x, y = data.to_numpy()[[i, j]]


### PR DESCRIPTION
This PR updates the notation for infinity in numpy from `np.infty` to `np.inf` for compatibility purposes in the `infotheory.py` file.